### PR TITLE
Improvements and fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.aleksey</groupId>
   <artifactId>castlegates</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.20-SNAPSHOT</version>
+  <version>1.0.21-SNAPSHOT</version>
   <name>CastleGates</name>
   <url>https://github.com/DevotedMC/CastleGates</url>
   
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>isaac</groupId>
       <artifactId>Bastion</artifactId>
-      <version>2.0.5</version>
+      <version>2.2.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/aleksey/castlegates/CastleGates.java
+++ b/src/main/java/com/aleksey/castlegates/CastleGates.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.aleksey.castlegates.engine.CastleGatesManager;
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
@@ -86,15 +87,6 @@ public class CastleGates extends JavaPlugin {
         	getLogger().log(Level.INFO, "Citadel plugin NOT found.");
         }
 
-        if(getServer().getPluginManager().getPlugin("Bastion") != null) {
-        	bastionManager = new BastionManager();
-        	bastionManager.init();
-        	getLogger().log(Level.INFO, "Bastion plugin found.");
-        } else {
-        	bastionManager = new NoBastionManager();
-        	getLogger().log(Level.INFO, "Bastion plugin NOT found.");
-        }
-
         if(getServer().getPluginManager().getPlugin("JukeAlert") != null) {
         	jukeAlertManager = new JukeAlertManager();
         	getLogger().log(Level.INFO, "JukeAlert plugin found.");
@@ -103,6 +95,7 @@ public class CastleGates extends JavaPlugin {
         	getLogger().log(Level.INFO, "JukeAlert plugin NOT found.");
         }
 
+        createBastionManager();
         createOrebfuscatorManager();
 
         // Load configurations
@@ -122,12 +115,12 @@ public class CastleGates extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new BlockListener(), this);
     }
 
-    private void createOrebfuscatorManager() {
-        Plugin plugin = getServer().getPluginManager().getPlugin("Orebfuscator4");
+    private void createBastionManager() {
+        Plugin plugin = getServer().getPluginManager().getPlugin("Bastion");
 
         if(plugin == null) {
-        	orebfuscatorManager = new NoOrebfuscatorManager();
-        	getLogger().log(Level.INFO, "Orebfuscator plugin NOT found.");
+            bastionManager = new NoBastionManager();
+        	getLogger().log(Level.INFO, "Bastion plugin NOT found.");
         	return;
         }
 
@@ -137,20 +130,53 @@ public class CastleGates extends JavaPlugin {
 	        int majorRevision = Integer.parseInt(versionParts[1]);
 	        int minorVersion = Integer.parseInt(versionParts[2].split("\\-")[0]);
 
-	        if(majorVersion > 4
-	        		|| majorVersion == 4 && majorRevision > 1
-	        		|| majorVersion == 4 && majorRevision == 1 && minorVersion > 0
+	        if(majorVersion > 2
+	        		|| majorVersion == 2 && majorRevision > 2
+	        		|| majorVersion == 2 && majorRevision == 2 && minorVersion >= 0
 	        		)
 	        {
-	        	orebfuscatorManager = new OrebfuscatorManager();
-	        	getLogger().log(Level.INFO, "Orebfuscator plugin found.");
+                bastionManager = new BastionManager();
+                bastionManager.init();
+	        	getLogger().log(Level.INFO, "Bastion plugin found.");
 	        } else {
-	        	orebfuscatorManager = new NoOrebfuscatorManager();
-	        	getLogger().log(Level.INFO, "Orebfuscator plugin found but old versions are NOT supported. You need to use the 4.1.1 version or newer.");
+                bastionManager = new NoBastionManager();
+	        	getLogger().log(Level.WARNING, ChatColor.YELLOW + "Bastion plugin found but old versions are NOT supported. You need to use the 2.2.0 version or newer.");
 	        }
         } catch (Exception e) {
-        	orebfuscatorManager = new NoOrebfuscatorManager();
-        	getLogger().log(Level.INFO, "Orebfuscator plugin found but this version is NOT supported.");
+            bastionManager = new NoBastionManager();
+        	getLogger().log(Level.INFO, ChatColor.YELLOW + "Bastion plugin found but this version is NOT supported.");
+        }
+    }
+
+    private void createOrebfuscatorManager() {
+        Plugin plugin = getServer().getPluginManager().getPlugin("Orebfuscator4");
+
+        if(plugin == null) {
+            orebfuscatorManager = new NoOrebfuscatorManager();
+            getLogger().log(Level.INFO, "Orebfuscator plugin NOT found.");
+            return;
+        }
+
+        try {
+            String[] versionParts = plugin.getDescription().getVersion().split("\\.");
+            int majorVersion = Integer.parseInt(versionParts[0]);
+            int majorRevision = Integer.parseInt(versionParts[1]);
+            int minorVersion = Integer.parseInt(versionParts[2].split("\\-")[0]);
+
+            if(majorVersion > 4
+                    || majorVersion == 4 && majorRevision > 1
+                    || majorVersion == 4 && majorRevision == 1 && minorVersion > 0
+                    )
+            {
+                orebfuscatorManager = new OrebfuscatorManager();
+                getLogger().log(Level.INFO, "Orebfuscator plugin found.");
+            } else {
+                orebfuscatorManager = new NoOrebfuscatorManager();
+                getLogger().log(Level.WARNING, ChatColor.YELLOW + "Orebfuscator plugin found but old versions are NOT supported. You need to use the 4.1.1 version or newer.");
+            }
+        } catch (Exception e) {
+            orebfuscatorManager = new NoOrebfuscatorManager();
+            getLogger().log(Level.INFO, ChatColor.YELLOW + "Orebfuscator plugin found but this version is NOT supported.");
         }
     }
 

--- a/src/main/java/com/aleksey/castlegates/config/ConfigManager.java
+++ b/src/main/java/com/aleksey/castlegates/config/ConfigManager.java
@@ -68,6 +68,7 @@ public class ConfigManager {
 	private int timerMax;
 	private int timerDefault;
 	private TimerOperation timerDefaultOperation;
+	private boolean gearblockMustBeReinforced;
 
 	public ConfigManager(Logger logger) {
 		this.logger = logger;
@@ -96,6 +97,7 @@ public class ConfigManager {
 		this.timerMax = getInt("Settings.Timer.Max", 60);
 		this.timerDefault = getInt("Settings.Timer.DefaultInterval", 5);
 		this.timerDefaultOperation = getTimerOperation("Settings.Timer.DefaultOperation", TimerOperation.UNDRAW);
+		this.gearblockMustBeReinforced = getBoolean("Settings.GearblockMustBeReinforced", false);
 
 		this.gearMaterials = getBlockMaterials("Blocks.GearMaterials", ConfigDefaults.gearMaterials);
 		this.bridgeMaterials = getBlockMaterials("Blocks.BridgeMaterials", ConfigDefaults.bridgeMaterials);
@@ -132,6 +134,8 @@ public class ConfigManager {
 	public TimerOperation getTimerDefaultOperation() {
 		return this.timerDefaultOperation;
 	}
+
+	public boolean isGearblockMustBeReinforced() { return this.gearblockMustBeReinforced; }
 
 	public Database getDatabase() {
 		return this.database;

--- a/src/main/java/com/aleksey/castlegates/engine/bridge/BridgeManager.java
+++ b/src/main/java/com/aleksey/castlegates/engine/bridge/BridgeManager.java
@@ -708,4 +708,33 @@ public class BridgeManager {
 
 		return CastleGates.getCitadelManager().getCitadel(players, location);
 	}
+
+	public boolean isSimpleGearblock(Gearblock gearblock, Player player) {
+		World world = player.getWorld();
+		BlockCoord coord = gearblock.getCoord();
+		List<Player> players = new ArrayList<>();
+
+		players.add(player);
+
+		ICitadel citadel = getCitadel(world, gearblock, players);
+
+		return !hasAccessibleGearblock(world, coord.getForward(), players, citadel)
+			&& !hasAccessibleGearblock(world, coord.getBackward(), players, citadel)
+			&& !hasAccessibleGearblock(world, coord.getRight(), players, citadel)
+			&& !hasAccessibleGearblock(world, coord.getLeft(), players, citadel)
+			&& !hasAccessibleGearblock(world, coord.getTop(), players, citadel)
+			&& !hasAccessibleGearblock(world, coord.getBottom(), players, citadel);
+	}
+
+	private boolean hasAccessibleGearblock(World world, BlockCoord coord, List<Player> players, ICitadel originalCitadel) {
+		Gearblock gearblock = this.storage.getGearblock(coord);
+
+		if(gearblock == null) return false;
+
+		ICitadel citadel = getCitadel(world, gearblock, players);
+
+		return originalCitadel.getGroupName() == null
+				? citadel.getGroupName() == null
+				: originalCitadel.getGroupName().equalsIgnoreCase(citadel.getGroupName());
+	}
 }

--- a/src/main/java/com/aleksey/castlegates/plugins/citadel/Citadel.java
+++ b/src/main/java/com/aleksey/castlegates/plugins/citadel/Citadel.java
@@ -24,10 +24,6 @@ public class Citadel implements ICitadel {
         this.useJukeAlert = useJukeAlert;
     }
 
-    public boolean hasAccess() {
-        return this.hasAccess;
-    }
-
     public boolean useJukeAlert() { return this.useJukeAlert; }
 
     public String getGroupName() {

--- a/src/main/java/com/aleksey/castlegates/plugins/citadel/CitadelManager.java
+++ b/src/main/java/com/aleksey/castlegates/plugins/citadel/CitadelManager.java
@@ -90,6 +90,12 @@ public class CitadelManager extends Thread implements ICitadelManager, Runnable 
 		return new com.aleksey.castlegates.plugins.citadel.Citadel(players, playerRein, hasAccess, useJukeAlert);
 	}
 
+	public boolean isReinforced(Location loc) {
+		Reinforcement rein = Citadel.getReinforcementManager().getReinforcement(loc);
+
+		return rein != null && (rein instanceof PlayerReinforcement);
+	}
+
 	public boolean canBypass(Player player, Location loc) {
 		Reinforcement rein = Citadel.getReinforcementManager().getReinforcement(loc);
 

--- a/src/main/java/com/aleksey/castlegates/plugins/citadel/ICitadel.java
+++ b/src/main/java/com/aleksey/castlegates/plugins/citadel/ICitadel.java
@@ -7,7 +7,6 @@ package com.aleksey.castlegates.plugins.citadel;
 import org.bukkit.Location;
 
 public interface ICitadel {
-    boolean hasAccess();
     boolean useJukeAlert();
     String getGroupName();
     boolean canAccessDoors(Location location);

--- a/src/main/java/com/aleksey/castlegates/plugins/citadel/ICitadelManager.java
+++ b/src/main/java/com/aleksey/castlegates/plugins/citadel/ICitadelManager.java
@@ -17,6 +17,7 @@ public interface ICitadelManager {
 	void close();
 	double getMaxRedstoneDistance();
 	ICitadel getCitadel(List<Player> players, Location loc);
+	boolean isReinforced(Location loc);
 	boolean canBypass(Player player, Location loc);
 	boolean canViewInformation(Player player, Location loc);
 	ReinforcementInfo removeReinforcement(Location loc);

--- a/src/main/java/com/aleksey/castlegates/plugins/citadel/NoCitadel.java
+++ b/src/main/java/com/aleksey/castlegates/plugins/citadel/NoCitadel.java
@@ -7,7 +7,6 @@ package com.aleksey.castlegates.plugins.citadel;
 import org.bukkit.Location;
 
 public class NoCitadel implements ICitadel {
-    public boolean hasAccess() { return true; }
     public boolean useJukeAlert() { return false; }
     public String getGroupName() { return null; }
     public boolean canAccessDoors(Location location) { return true; }

--- a/src/main/java/com/aleksey/castlegates/plugins/citadel/NoCitadelManager.java
+++ b/src/main/java/com/aleksey/castlegates/plugins/citadel/NoCitadelManager.java
@@ -28,6 +28,8 @@ public class NoCitadelManager implements ICitadelManager {
 
 	public ICitadel getCitadel(List<Player> players, Location loc) { return new NoCitadel(); }
 
+	public boolean isReinforced(Location loc) { return false; }
+
 	public boolean canBypass(Player player, Location loc) {
 		return true;
 	}


### PR DESCRIPTION
1. Plugin now is compatible only with Bastion 2.2.0 or newer.

2. Added support for allowed bastion groups. If group is allowed for bastion and player has DOORS perms in this group then player could open/close gates in bastioned field.

3. Fixed "simple activation". Previously it allowed to activate CG even for complex constructions which shouldn't be allowed.

4. Introduced new config option Settings.GearblockMustBeReinforced (default value False). When it has value True then gearblock could be created only for Citadel reinforced block.