### PR TITLE
Fix bug: links sometimes were failing to initialize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.aleksey</groupId>
   <artifactId>castlegates</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.22-SNAPSHOT</version>
+  <version>1.0.23-SNAPSHOT</version>
   <name>CastleGates</name>
   <url>https://github.com/DevotedMC/CastleGates</url>
   

--- a/src/main/java/com/aleksey/castlegates/engine/PlayerStateManager.java
+++ b/src/main/java/com/aleksey/castlegates/engine/PlayerStateManager.java
@@ -6,7 +6,7 @@
 package com.aleksey.castlegates.engine;
 
 import java.util.Map;
-import java.util.WeakHashMap;
+import java.util.HashMap;
 
 import com.aleksey.castlegates.CastleGates;
 import com.aleksey.castlegates.types.TimerMode;
@@ -26,8 +26,8 @@ public class PlayerStateManager {
 		public long lastInteracted;
 	}
 
-	private Map<Player, PlayerState> states = new WeakHashMap<Player, PlayerState>();
-	private Map<Player, Integer> tasks = new WeakHashMap<Player, Integer>();
+	private Map<Player, PlayerState> states = new HashMap<Player, PlayerState>();
+	private Map<Player, Integer> tasks = new HashMap<Player, Integer>();
 
 	public void clearPlayerMode(Player player) {
 		Integer taskId = this.tasks.get(player);

--- a/src/main/java/com/aleksey/castlegates/engine/bridge/BridgeManager.java
+++ b/src/main/java/com/aleksey/castlegates/engine/bridge/BridgeManager.java
@@ -48,7 +48,7 @@ public class BridgeManager {
 
 	public void init(StorageManager storage) {
 		this.storage = storage;
-		this.pendingTimerBatches = new WeakHashMap<>();
+		this.pendingTimerBatches = new HashMap<>();
 
 		this.timerWorker = new TimerWorker(this);
 		this.timerWorker.startThread();

--- a/src/main/java/com/aleksey/castlegates/plugins/jukealert/IJukeAlertManager.java
+++ b/src/main/java/com/aleksey/castlegates/plugins/jukealert/IJukeAlertManager.java
@@ -1,10 +1,6 @@
 package com.aleksey.castlegates.plugins.jukealert;
 
-import com.aleksey.castlegates.plugins.citadel.ICitadel;
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
-
-import java.util.List;
 
 public interface IJukeAlertManager {
 	boolean hasJukeAlertAccess(Location location, String groupName);

--- a/src/main/java/com/aleksey/castlegates/utils/DataWorker.java
+++ b/src/main/java/com/aleksey/castlegates/utils/DataWorker.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.WeakHashMap;
+import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
@@ -37,8 +37,8 @@ public class DataWorker extends Thread implements Runnable {
 	private ReinforcementSource reinforcementSource;
 	private ChangeLogger changeLogger;
 
-	private Map<Gearblock, GearblockForUpdate> changedGearblocks = new WeakHashMap<Gearblock, GearblockForUpdate>();
-	private Map<GearblockLink, LinkForUpdate> changedLinks = new WeakHashMap<GearblockLink, LinkForUpdate>();
+	private Map<Gearblock, GearblockForUpdate> changedGearblocks = new HashMap<Gearblock, GearblockForUpdate>();
+	private Map<GearblockLink, LinkForUpdate> changedLinks = new HashMap<GearblockLink, LinkForUpdate>();
 
 	private ArrayList<GearblockForUpdate> localChangedGearblocks = new ArrayList<GearblockForUpdate>();
 	private ArrayList<LinkForUpdate> localChangedLinks = new ArrayList<LinkForUpdate>();
@@ -65,9 +65,9 @@ public class DataWorker extends Thread implements Runnable {
 	}
 
 	public Map<BlockCoord, Gearblock> load() throws SQLException {
-		Map<BlockCoord, Gearblock> gearblocks = new WeakHashMap<BlockCoord, Gearblock>();
-		Map<Integer, Gearblock> gearblocksById = new WeakHashMap<Integer, Gearblock>();
-		Map<Integer, GearblockLink> linksById = new WeakHashMap<Integer, GearblockLink>();
+		Map<BlockCoord, Gearblock> gearblocks = new HashMap<BlockCoord, Gearblock>();
+		Map<Integer, Gearblock> gearblocksById = new HashMap<Integer, Gearblock>();
+		Map<Integer, GearblockLink> linksById = new HashMap<Integer, GearblockLink>();
 
 		loadGears(gearblocks, gearblocksById);
 		loadLinks(linksById, gearblocksById);

--- a/src/main/java/com/aleksey/castlegates/utils/TimerWorker.java
+++ b/src/main/java/com/aleksey/castlegates/utils/TimerWorker.java
@@ -68,7 +68,7 @@ public class TimerWorker extends Thread implements Runnable {
         this.run.set(true);
 
         try {
-            Map<Gearblock, TimerBatch> localBatchMap = new WeakHashMap<Gearblock, TimerBatch>();
+            Map<Gearblock, TimerBatch> localBatchMap = new HashMap<Gearblock, TimerBatch>();
             List<TimerBatch> localBatches = new ArrayList<TimerBatch>();
 
             while (!this.isInterrupted() && !this.kill.get()) {


### PR DESCRIPTION
Fixed the bug that first happened at Dev 3.0 times and re-appeared now in CivRealms 2.0
A long time ago I was blaming "problems with the database" but actually this is a bug in the code.
Sometimes gearblocks loaded in WeakHashMap are removed by GC before they are used for the initialization of links during the server startup.